### PR TITLE
Percentage of Invoices not Shipped

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -64,6 +64,19 @@ class SalesAnalyst
     (average_prices / merchants.size).round(2)
   end
 
+  def invoice_status(status_symbol)
+    total_invoices = invoices.count.to_f
+
+    if status_symbol == :shipped
+      requested_type_count = invoices.count { |invoice| invoice.status == "shipped"}
+    elsif status_symbol == :pending
+      requested_type_count = invoices.count { |invoice| invoice.status == "pending"}
+    elsif status_symbol == :returned
+      requested_type_count = invoices.count { |invoice| invoice.status == "returned"}
+    end
+    (requested_type_count / total_invoices) * 100
+  end
+
   private
 
   def item_repo
@@ -74,12 +87,20 @@ class SalesAnalyst
     engine.merchants
   end
 
+  def invoice_repo
+    engine.invoices
+  end
+
   def items
     item_repo.all
   end
 
   def merchants
     merchant_repo.all
+  end
+
+  def invoices
+    invoice_repo.all
   end
 
   def items_by_merchant_id(id)

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -66,14 +66,7 @@ class SalesAnalyst
 
   def invoice_status(status_symbol)
     total_invoices = invoices.count.to_f
-
-    if status_symbol == :shipped
-      requested_type_count = invoices.count { |invoice| invoice.status == "shipped"}
-    elsif status_symbol == :pending
-      requested_type_count = invoices.count { |invoice| invoice.status == "pending"}
-    elsif status_symbol == :returned
-      requested_type_count = invoices.count { |invoice| invoice.status == "returned"}
-    end
+    requested_type_count = invoices.count { |invoice| invoice.status == status_symbol.to_s}
     (requested_type_count / total_invoices) * 100
   end
 

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -49,4 +49,22 @@ class SalesAnalystTest < Minitest::Test
     assert_equal ['Custom Hand Made Miniature Bicycle'], golden_array
   end
 
+  def test_it_can_calculate_the_percentage_of_invoices_shipped
+    result = @analyst.invoice_status(:shipped)
+
+    assert_equal 50.0, result
+  end
+
+  def test_it_can_calculate_the_percentage_of_invoices_pending
+    result = @analyst.invoice_status(:pending)
+
+    assert_equal 10.0, result
+  end
+
+  def test_it_can_calculate_the_percentage_of_invoices_returned
+    result = @analyst.invoice_status(:returned)
+
+    assert_equal 40.0, result
+  end
+
 end


### PR DESCRIPTION
This feature gives SalesAnalyst the ability to report on the percentage of invoices that match a given status.
