### PR TITLE
Completed top_days_by_invoice_count

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -70,6 +70,27 @@ class SalesAnalyst
     (requested_type_count / total_invoices) * 100
   end
 
+  def top_days_by_invoice_count
+    totals = [0,0,0,0,0,0,0]
+    invoices.each do |invoice|
+      totals[invoice.created_at.wday] += 1
+    end
+
+    threshold = (totals.reduce(:+)/totals.length) +
+                standard_deviation(totals)
+
+    result = []
+    result << "Sunday" if totals[0] > threshold
+    result << "Monday" if totals[1] > threshold
+    result << "Tuesday" if totals[2] > threshold
+    result << "Wednesday" if totals[3] > threshold
+    result << "Thursday" if totals[4] > threshold
+    result << "Friday" if totals[5] > threshold
+    result << "Saturday" if totals[6] > threshold
+
+    result
+  end
+
   private
 
   def item_repo

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -70,14 +70,17 @@ class SalesAnalyst
     (requested_type_count / total_invoices) * 100
   end
 
-  def top_days_by_invoice_count
+  def invoice_totals_by_day
     totals = [0,0,0,0,0,0,0]
     invoices.each do |invoice|
       totals[invoice.created_at.wday] += 1
     end
+    totals
+  end
 
-    threshold = (totals.reduce(:+)/totals.length) +
-                standard_deviation(totals)
+  def top_days_by_invoice_count
+    threshold = (invoice_totals_by_day.reduce(:+)/invoice_totals_by_day.length) +
+                  standard_deviation(invoice_totals_by_day)
 
     result = []
     result << "Sunday" if totals[0] > threshold

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -83,13 +83,13 @@ class SalesAnalyst
                   standard_deviation(invoice_totals_by_day)
 
     result = []
-    result << "Sunday" if totals[0] > threshold
-    result << "Monday" if totals[1] > threshold
-    result << "Tuesday" if totals[2] > threshold
-    result << "Wednesday" if totals[3] > threshold
-    result << "Thursday" if totals[4] > threshold
-    result << "Friday" if totals[5] > threshold
-    result << "Saturday" if totals[6] > threshold
+    result << "Sunday" if invoice_totals_by_day[0] > threshold
+    result << "Monday" if invoice_totals_by_day[1] > threshold
+    result << "Tuesday" if invoice_totals_by_day[2] > threshold
+    result << "Wednesday" if invoice_totals_by_day[3] > threshold
+    result << "Thursday" if invoice_totals_by_day[4] > threshold
+    result << "Friday" if invoice_totals_by_day[5] > threshold
+    result << "Saturday" if invoice_totals_by_day[6] > threshold
 
     result
   end

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -67,4 +67,9 @@ class SalesAnalystTest < Minitest::Test
     assert_equal 40.0, result
   end
 
+  def test_it_can_calculate_the_days_invoices_are_created_more
+    result = @analyst.top_days_by_invoice_count
+
+    assert_equal ["Monday"], result
+  end
 end


### PR DESCRIPTION
This method calculates which days have more invoices than the standard deviation + mean.

Closes 32.
